### PR TITLE
Fix config path and analytics enabled check

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -32,9 +32,8 @@ fastify.addHook('onResponse', async (request, reply) => {
 
     routePartFiltered.unshift('/');
 
-    if (request.headers['DNT'] === 1) return;
-    if (!config?.['analytics']['work'] ? config?.['analytics']['work'] : false)
-        return;
+    if (request.headers['dnt'] === '1') return;
+    if (!config?.['analytics']['enabled']) return;
     else if (!fastify.printRoutes().includes(routePartFiltered.at(-1))) return;
 
     const userAgent = request.headers['user-agent'];

--- a/shared/config/src/main.js
+++ b/shared/config/src/main.js
@@ -1,10 +1,13 @@
 const fs = require('fs');
 const hjson = require('hjson');
 
-const config = () => {
-    if (!fs.existsSync('../config.hjson')) throw new Error('Config not found');
+const path = require('path');
 
-    return hjson.parse(fs.readFileSync('../config.hjson', 'utf-8'));
+const config = () => {
+    const configPath = path.join(__dirname, '../../../config.hjson');
+    if (!fs.existsSync(configPath)) throw new Error('Config not found');
+
+    return hjson.parse(fs.readFileSync(configPath, 'utf-8'));
 };
 
 module.exports = config;

--- a/shared/database/src/create_table.js
+++ b/shared/database/src/create_table.js
@@ -4,7 +4,7 @@ const path = require('path');
 const logger = require('../../logger/src/main.js');
 
 async function create_table() {
-    const filePath = path.join('/shared/database/schemas/data.sql');
+    const filePath = path.join(__dirname, '../schemas/data.sql');
 
     let schema;
     try {


### PR DESCRIPTION
## Summary
- correct path resolution for `config.hjson`
- use `analytics.enabled` flag in the server

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684ece9905dc832cb654ddd715e704ec